### PR TITLE
L10DD-26: Adding config split installation and setup

### DIFF
--- a/files/scripts/config_split/config-safety-check.sh
+++ b/files/scripts/config_split/config-safety-check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Pre-deployment config safety check
+# Run this before pushing to ensure config sync safety
+
+# Change to project root directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT" || exit
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Pre-Deployment Config Safety Check${NC}"
+echo "==================================="
+echo "Working directory: $(pwd)"
+echo ""
+
+ERRORS=0
+
+# Check 1: Ensure no dev modules are enabled in main config
+echo "1. Checking for dev modules in core.extension.yml..."
+if grep -q "devel: 0" config/sync/core.extension.yml || grep -q "reroute_email: 0" config/sync/core.extension.yml; then
+    echo -e "${RED}✗ WARNING: Development modules found in main config${NC}"
+    echo "  Development modules should only be in the dev config split"
+    ERRORS=$((ERRORS + 1))
+else
+    echo -e "${GREEN}✓ No dev modules in main config${NC}"
+fi
+
+# Check 2: Ensure config split is properly configured
+echo "2. Checking config split configuration..."
+if [[ -f "config/sync/config_split.config_split.dev.yml" ]]; then
+    if grep -q "status: false" config/sync/config_split.config_split.dev.yml; then
+        echo -e "${GREEN}✓ Dev config split is disabled in main config${NC}"
+    else
+        echo -e "${RED}✗ ERROR: Dev config split is enabled in main config${NC}"
+        echo "  This could enable dev modules on production!"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    echo -e "${YELLOW}⚠ No dev config split found${NC}"
+fi
+
+# Check 3: Verify environment-specific files aren't in sync (except config_split definitions)
+echo "3. Checking for environment-specific config in sync..."
+ENV_FILES=$(find config/sync/ -name "*\.dev\.yml" -o -name "*\.local\.yml" -o -name "*\.staging\.yml" -o -name "*\.prod\.yml" 2>/dev/null | grep -v "config_split.config_split" | head -5)
+if [[ -n "$ENV_FILES" ]]; then
+    echo -e "${RED}✗ WARNING: Environment-specific config found in sync:${NC}"
+    echo "$ENV_FILES"
+    echo "  These should be in separate config split directories"
+    ERRORS=$((ERRORS + 1))
+else
+    echo -e "${GREEN}✓ No problematic environment-specific config in main sync${NC}"
+fi
+
+# Check 4: Config sync directory is correct
+echo "4. Checking config sync directory setting..."
+# Check the actual Drupal config sync directory using drush
+if cd html && lando drush status --field=config-sync 2>/dev/null | grep -q "../config/sync"; then
+    echo -e "${GREEN}✓ Config sync directory correctly set${NC}"
+else
+    echo -e "${RED}✗ ERROR: Config sync directory not properly configured${NC}"
+    echo "  Expected: ../config/sync"
+    echo "  Current: $(cd html && lando drush status --field=config-sync 2>/dev/null || echo 'Unable to determine')"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}🎉 All safety checks passed! Safe to deploy.${NC}"
+    exit 0
+else
+    echo -e "${RED}❌ ${ERRORS} safety check(s) failed. Please fix before deploying.${NC}"
+    echo ""
+    echo "Common fixes:"
+    echo "- Run 'lando drush config-split:deactivate dev' if dev split is accidentally active"
+    echo "- Run 'lando drush cex -y' to export config after fixing"
+    echo "- Ensure dev modules are only in profiles/wavemetrics/config/dev/"
+    exit 1
+fi

--- a/files/scripts/config_split/dev-config.sh
+++ b/files/scripts/config_split/dev-config.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# Simple dev config management for Lando
+# Usage:
+#   ./dev-config.sh enable   - Enable dev modules
+#   ./dev-config.sh disable  - Disable dev modules
+
+ACTION="${1:-enable}"
+FORCE="${2}"
+
+# Colors for output
+RED="\033[31m"
+GREEN='\033[0;32m'
+YELLOW="\033[33m"
+NORMAL="\033[0m"
+
+# Only enable dev config in Lando
+if [[ -z "${LANDO_INFO}" ]]; then
+    echo -e "${RED}ERROR: This script should only be run in Lando environments.${NORMAL}"
+    exit 1
+fi
+
+wait_for_database() {
+    echo -e "${YELLOW}⏳ Waiting for database to be ready...${NORMAL}"
+    local max_attempts=30
+    local attempt=1
+
+    while [ $attempt -le $max_attempts ]; do
+        # Test database connectivity by checking if Drupal can connect to DB
+        if drush core:status 2>/dev/null | grep -q "Drupal version" ; then
+            echo -e "${GREEN}✅ Database is ready${NORMAL}"
+            return 0
+        fi
+
+        echo "   Attempt $attempt/$max_attempts..."
+        sleep 2
+        ((attempt++))
+    done
+
+    echo -e "${RED}❌ Database not ready after $max_attempts attempts${NORMAL}"
+    return 1
+}
+
+# For enable action, always wait for database. For disable, just do a quick check.
+if [[ "$ACTION" == "enable" ]]; then
+    if ! wait_for_database && [[ "$FORCE" != "-f" ]]; then
+        echo -e "${YELLOW}⚠️  Database not ready. Skipping config operation.${NORMAL}"
+        echo -e "${YELLOW}   Use '$0 $ACTION -f' to force if needed.${NORMAL}"
+        exit 0
+    fi
+elif [[ "$ACTION" == "disable" ]] && ! drush core:status 2>/dev/null | grep -q "Drupal version" ; then
+    if [[ "$FORCE" != "-f" ]]; then
+        echo -e "${YELLOW}⚠️  Database not ready. Skipping config operation.${NORMAL}"
+        echo -e "${YELLOW}   Use '$0 $ACTION -f' to force if needed.${NORMAL}"
+        exit 0
+    fi
+fi
+
+case "$ACTION" in
+    "enable")
+        echo -e "${YELLOW}🔧 Enabling dev config split...${NORMAL}"
+
+        # Install git hooks on first enable (simple one-time setup)
+        if [[ ! -f "/app/.git/hooks/pre-commit" ]] && [[ -f "/app/.githooks/pre-commit" ]]; then
+            cp /app/.githooks/pre-commit /app/.git/hooks/pre-commit
+            chmod +x /app/.git/hooks/pre-commit
+            echo -e "${GREEN}✅ Git hooks installed for config safety${NORMAL}"
+        fi
+
+        # Use settings.local.php override (more persistent across DB pulls)
+        echo -e "${YELLOW}Configuring dev split in settings.local.php...${NORMAL}"
+
+        # Ensure settings.local.php exists
+        if [[ ! -f "/app/html/sites/default/settings.local.php" ]]; then
+            cp /app/html/sites/default/default.settings.local.php /app/html/sites/default/settings.local.php
+        fi
+
+        # Use PHP to safely modify the settings file
+        php -r "
+        \$file = '/app/html/sites/default/settings.local.php';
+        \$content = file_get_contents(\$file);
+
+        // Add config split overrides if they don't exist
+        if (strpos(\$content, 'config_split.config_split.dev') === false) {
+            \$content .= PHP_EOL . '// Enable dev config split' . PHP_EOL;
+            \$content .= '\$config[\"config_split.config_split.dev\"][\"status\"] = TRUE;' . PHP_EOL;
+        } else {
+            // Update existing entries
+            \$content = preg_replace('/\\\$config\[.config_split\.config_split\.dev.\]\[.status.\] = FALSE;/', '\$config[\"config_split.config_split.dev\"][\"status\"] = TRUE;', \$content);
+        }
+
+        file_put_contents(\$file, \$content);
+        echo 'Settings updated successfully';
+        "
+
+        # Clear cache and activate
+        drush cr
+
+        if drush config-split:activate dev -y 2>/dev/null; then
+            echo -e "${GREEN}✅ Dev modules enabled${NORMAL}"
+        else
+            echo -e "${YELLOW}⚠️  Dev config activation had issues (often missing dependencies)${NORMAL}"
+            echo -e "${YELLOW}   Config override is in place, run 'drush cr' after installing dependencies${NORMAL}"
+        fi
+        ;;
+
+    "disable")
+        echo -e "${YELLOW}🔧 Disabling dev config split...${NORMAL}"
+
+        # Remove from settings.local.php
+        if [[ -f "/app/html/sites/default/settings.local.php" ]]; then
+            php -r "
+            \$file = '/app/html/sites/default/settings.local.php';
+            \$content = file_get_contents(\$file);
+            \$content = preg_replace('/\\\$config\[.config_split\.config_split\.dev.\]\[.status.\] = TRUE;/', '\$config[\"config_split.config_split.dev\"][\"status\"] = FALSE;', \$content);
+            file_put_contents(\$file, \$content);
+            echo 'Settings updated successfully';
+            "
+        fi
+
+        drush config-split:deactivate dev -y 2>/dev/null || echo "Config split already inactive"
+        drush cr
+        echo -e "${GREEN}✅ Dev modules disabled${NORMAL}"
+        ;;
+
+    *)
+        echo "Usage: $0 {enable|disable} [-f]"
+        echo "  enable   - Enable dev modules"
+        echo "  disable  - Disable dev modules"
+        echo "  -f       - Force action even if database not ready"
+        exit 1
+        ;;
+esac

--- a/files/scripts/config_split/update-lando-file.sh
+++ b/files/scripts/config_split/update-lando-file.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script updates the .lando.yml file with the following changes
+# - Adds three new commands in tooling section:
+#   - dev-config [enable|disable]
+#   - safe-export
+#   - config-check
+#
+# - Adds the following commands to pre-start event:
+#   - appserver: echo "🔧 Setting up dev environment..."
+#   - appserver: bash /app/lando/scripts/dev-config.sh enable
+#
+# - Adds the following commands to the post-pull event:
+#   - appserver: bash /app/lando/scripts/dev-config.sh disable
+#   - appserver: drush cr

--- a/src/InstallConfigSplit.php
+++ b/src/InstallConfigSplit.php
@@ -1,0 +1,351 @@
+<?php
+declare(strict_types=1);
+
+namespace HelloWorldDevs\PantheonCI;
+
+use Composer\IO\IOInterface;
+use Composer\Json\JsonManipulator;
+use Symfony\Component\Yaml\Yaml;
+
+class InstallConfigSplit {
+
+  /**
+   * @var IOInterface
+   */
+  private $io;
+
+  /**
+   * @var string
+   */
+  private $projectRoot;
+
+  /**
+   * @var string
+   */
+  private $configSplitPackage = 'drupal/config_split';
+
+  /**
+   * @var string
+   */
+  private $configSplitVersion = '^2.0';
+
+  /**
+   * @var string
+   */
+  private $scriptDir = __DIR__ . '/../files/scripts/config_split';
+
+  private $landoScripts = [
+    'config-safety-check.sh',
+    'dev-config.sh'
+  ];
+
+  public function __construct(IOInterface $io, $projectRoot) {
+    $this->io = $io;
+    $this->projectRoot = $projectRoot;
+  }
+
+  /**
+   * Installs the necessary configuration for the config split.
+   */
+  public function install() : void {
+
+    $this->io->write('  - Installing Config Split setup...');
+    if (!$this->require_package()) {
+      $this->io->writeError('  - Error: could not ensure Config Split is a dev requirement; aborting config split installation.');
+      $this->io->write(sprintf("  - Please install manually via composer require --dev '%s:%s'.", $this->configSplitPackage, $this->configSplitVersion));
+      $this->io->write(sprintf('  - Please run "composer update %s --with-all-dependencies" to install it.', $this->configSplitPackage));
+      return;
+    }
+    
+    if (!$this->installLandoScripts()) {
+      $this->io->writeError('  - Error: could not install Lando scripts; aborting config split installation.');
+      return;
+    }
+    if (!$this->modifyLandoFile()) {
+      $this->io->writeError('  - Error: could not modify .lando.yml; aborting config split installation.');
+      return;
+    }
+  }
+
+  /**
+   * Modifies the .lando.yml file to include necessary configurations.
+   * Parses YAML and updates it with new events and commands.
+   *
+   * @return bool True if successful, false if not.
+   */
+  protected function modifyLandoFile() : bool {
+    $filePath = rtrim($this->projectRoot, '/'). '/.lando.yml';
+    $backupFile = $filePath . '.bak';
+
+    if (!file_exists($filePath)) {
+      $this->io->writeError(sprintf('  - Warning: .lando.yml not found at %s; skipping Lando modification.', $filePath));
+      return false;
+    }
+
+    if (!copy($filePath, $backupFile)) {
+      $this->io->writeError(sprintf('  - Error: failed to create backup copy of %s', $filePath));
+      return false;
+    }
+
+    $yaml = $this->parseYamlFile($filePath);
+    if (!\is_array($yaml)) {
+      $this->io->writeError(sprintf('  - Error: failed to parse YAML from %s', $filePath));
+      return false;
+    }
+
+    // Ensure structure.
+    $yaml['events'] = $yaml['events'] ?? [];
+    $yaml['events']['post-start'] = $yaml['events']['post-start'] ?? [];
+    $yaml['events']['post-pull'] = $yaml['events']['post-pull'] ?? [];
+    $yaml['tooling'] = $yaml['tooling'] ?? [];
+
+    // Merge events uniquely.
+    $yaml['events']['post-start'] = self::mergeUnique($yaml['events']['post-start'], self::postStartEvents());
+    $yaml['events']['post-pull'] = self::mergeUnique($yaml['events']['post-pull'], self::postPullEvents());
+
+    // Tooling: overwrite existing command definitions with new ones (safer for updates).
+    foreach (self::newLandoCommands() as $cmdName => $definition) {
+      $yaml['tooling'][$cmdName] = $definition;
+    }
+
+    $yamlString = $this->dumpYaml($yaml);
+    if (file_put_contents($filePath, $yamlString) === false) {
+      $this->io->writeError(sprintf('  - Error: failed to write changes to %s', $filePath));
+      if (!\file_put_contents($filePath, file_get_contents($backupFile))) {
+        $this->io->writeError(sprintf('  - Error: failed to restore backup copy to %s', $filePath));
+        $this->io->writeError(sprintf("  - Manually copy contents of %s to %s", $backupFile, $filePath));
+      }
+      $this->io->writeError(sprintf('  - Restored %s from to original state', $filePath));
+      return false;
+    }
+
+    $this->io->write('  - Added dev environment setup commands to .lando.yml post-start events');
+
+    $this->io->write('  - Successfully parsed .lando.yml file');
+
+    return true;
+
+  }
+
+  /**
+   * Returns the post-pull events to write to Lando configuration
+   * as an integer-indexed array.
+   *
+   * @return array
+   */
+  protected static function postPullEvents() : array {
+    return [
+      'appserver: bash /app/lando/scripts/dev-config.sh disable',
+      'appserver: drush cr'
+    ];
+  }
+
+  /**
+   * Returns the post-start events to write to Lando configuration as
+   * an integer-indexed array.
+   *
+   * @return array
+   */
+  protected static function postStartEvents() : array {
+    return [
+      'appserver: echo "🔧 Setting up dev environment..."',
+      'appserver: bash /app/lando/scripts/dev-config.sh enable'
+    ];
+  }
+
+  /**
+   * Returns the new Lando commands to write to Lando configuration
+   * as multidimensional array.
+   *
+   * @return array
+   */
+  protected static function newLandoCommands() : array {
+    return [
+      'dev-config' => [
+        'service' => 'appserver',
+        'description' => 'Enable/disable dev config split (usage - dev-config enable|disable)',
+        'cmd' => 'bash /app/lando/scripts/dev-config.sh'
+      ],
+      'config-check' => [
+        'service' => 'appserver',
+        'description' => 'Check the configuration split (usage - config-check)',
+        'cmd' => 'bash /app/lando/scripts/config-safety-check.sh'
+      ],
+      'safe-export' => [
+        'service' => 'appserver',
+        'description' => 'Export the configuration split (usage - safe-export)',
+        'cmd' => [
+          'echo "🔍 Preparing safe config export..."',
+          'bash /app/lando/scripts/dev-config.sh disable',
+          'bash /app/lando/scripts/config-safety-check.sh',
+          'drush cex -y',
+          'echo "✅ Config exported safely"'
+        ]
+      ]
+    ];
+  }
+
+  /**
+   * Copies the necessary Lando scripts to the project directory.
+   * Scripts installed defined in `$this->landoScripts`.
+   *
+   * @return bool True if successful, false if not.
+   */
+  protected function installLandoScripts() : bool {
+    $landoScriptsDir = rtrim($this->projectRoot, '/'). '/lando/scripts';
+
+    if (!\is_dir($landoScriptsDir) && !\mkdir($landoScriptsDir, 0755, true) && !\is_dir($landoScriptsDir)) {
+      $this->io->writeError(sprintf('  - Error: failed to create Lando scripts directory %s', $landoScriptsDir));
+      return false;
+    }
+    if (!\is_dir($landoScriptsDir)) {
+      $this->io->writeError(sprintf('  - Error: Lando scripts directory %s is not a directory', $landoScriptsDir));
+      return false;
+    }
+
+    foreach ($this->landoScripts as $script) {
+      $tarPath = $landoScriptsDir . '/' . $script;
+      if (file_exists($tarPath)) {
+        $this->io->write(sprintf('  - Lando script %s already exists; skipping.', $script));
+        continue;
+      }
+      if (!copy($this->scriptDir . '/' . $script, $tarPath)) {
+        $this->io->writeError(sprintf('  - Error: failed to copy %s to %s', $script, $tarPath));
+        return false;
+      }
+      if (!chmod($tarPath, 0755)) {
+        $this->io->writeError(sprintf('  - Error: failed to make executable: %s', $script));
+        return false;
+      }
+      $this->io->write(sprintf('  - Copied and made executable: %s', $script));
+    }
+
+    $this->io->write('  - All Lando scripts have been copied successfully!');
+
+    return true;
+  }
+  
+  /**
+   * Ensure a dev requirement exists in composer.json.
+   *
+   * This only mutates composer.json; it does NOT run Composer. Safer for scripts.
+   *
+   * @param string $package     e.g. 'drupal/config_split'
+   * @param string $constraint  e.g. '^2.0'
+   * @param string $projectRoot Absolute path to the project root containing composer.json
+   * @return bool True if package is installed or already exists, false if not
+   */
+  protected function require_package(): bool
+  {
+    $this->io->write("  - Checking for Config Split...");
+      $composerFile = rtrim($this->projectRoot, '/').'/composer.json';
+      if (!file_exists($composerFile)) {
+          $this->io->write(sprintf('  - Warning: composer.json not found at %s; skipping dev requirement check.', $composerFile));
+          return false;
+      }
+
+      $contents = file_get_contents($composerFile);
+      if ($contents === false) {
+          $this->io->writeError(sprintf('  - Error: could not read %s', $composerFile));
+          return false;
+      }
+
+      $decoded = json_decode($contents, true);
+      if (!is_array($decoded)) {
+          $this->io->writeError(sprintf('  - Error: %s is not valid JSON', $composerFile));
+          return false;
+      }
+
+      $alreadyPresent = (
+        isset($decoded['require-dev']) && is_array($decoded['require-dev']) &&
+        array_key_exists($this->configSplitPackage, $decoded['require-dev'])
+      );
+      if ($alreadyPresent) {
+          $this->io->write(sprintf('  - %s already present in require-dev.', $this->configSplitPackage));
+          return true;
+      }
+
+      $manip = new JsonManipulator($contents);
+      if (!$manip->addLink('require-dev', $this->configSplitPackage, $this->configSplitVersion, /* sort */ true)) {
+          $this->io->writeError(sprintf('  - Error: failed to add %s:%s to require-dev.', $this->configSplitPackage, $this->configSplitVersion));
+          return false;
+      }
+
+      if (file_put_contents($composerFile, $manip->getContents()) === false) {
+          $this->io->writeError(sprintf('  - Error: failed writing changes to %s', $composerFile));
+          return false;
+      }
+
+      $this->io->write(sprintf('  - Added %s:%s to require-dev.', $this->configSplitPackage, $this->configSplitVersion));
+      $this->io->write('    Next step: run "composer update '.$this->configSplitPackage.' --with-all-dependencies" to install it.');
+
+      return true;
+  }
+
+  /**
+   * Parse YAML file with PECL yaml or Symfony Yaml as fallback.
+   */
+  private function parseYamlFile(string $filePath): ?array {
+    try {
+      if (\function_exists('yaml_parse_file')) {
+        $data = \yaml_parse_file($filePath);
+        return \is_array($data) ? $data : null;
+      }
+      return Yaml::parseFile($filePath);
+    } catch (\Throwable $e) {
+      $this->io->writeError('  - YAML parse error: '.$e->getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Dump YAML using available implementation.
+   */
+  private function dumpYaml(array $data): string {
+    try {
+      if (\function_exists('yaml_emit')) {
+        return (string) \yaml_emit($data);
+      }
+      return Yaml::dump($data, 6, 2);
+    } catch (\Throwable $e) {
+      $this->io->writeError('  - YAML dump error: '.$e->getMessage());
+      return "# YAML dump failed; JSON fallback\n".json_encode($data, JSON_PRETTY_PRINT);
+    }
+  }
+
+  /**
+   * Merge two indexed arrays preserving order & uniqueness.
+   */
+  private static function mergeUnique(array $existing, array $additions): array {
+    $result = $existing;
+    $signatures = [];
+
+    // Build signature list from existing.
+    foreach ($existing as $item) {
+      $signatures[] = self::eventSignature($item);
+    }
+
+    foreach ($additions as $item) {
+      $sig = self::eventSignature($item);
+      if (!in_array($sig, $signatures, true)) {
+        $result[] = $item;
+        $signatures[] = $sig;
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * Normalize an event entry (string or mapping) to a signature for uniqueness.
+   *
+   * @param mixed $item
+   */
+  private static function eventSignature($item): string {
+    if (is_array($item)) {
+      // Sort keys for stable signature.
+      ksort($item);
+      return 'A:'.json_encode($item, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+    return 'S:'.(string)$item;
+  }
+}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -26,6 +26,9 @@ class Installer
     {
         $this->io->write('  - Copying CI configuration files...');
         $this->copyFiles();
+
+        $configSplitInstaller = new InstallConfigSplit($this->io, $this->findProjectRoot());
+        $configSplitInstaller->install();
     }
 
     /**


### PR DESCRIPTION
## Changes

- Added Drupal config split scripts to repo
- Added installer class for installation of config split scripts and updating Lando YAML configuration

> ⚠️ Note that since QA uses a file path, the way the scripts are referenced during installation prevent it from working from within the appserver container at the moment. In other words, `lando composer install` will fail while `composer install` will work correctly. This will be resolved when the changes are merged into the GitHub repository.

## QA Steps

1. Pull down this repo `gh repo clone helloworlddevs/pantheon-ci-tools`
2. Go into the repo for a site that uses the Pantheon CI tools (Wave Metrics or DoveLewis come to mind) and update the `composer.json` file by changing the following section:

```json
{
    "type": "vcs",
    "url": "https://github.com/helloworlddevs/pantheon-ci-tools.git"
},
```

with the following:

```json
{
    "type": "path",
    "url": "/Users/ryne/code/HelloWorld/repos/pantheon-ci-tools"
},
```

3. Run `composer install --dev` and verify via the console output that the config split install script was run successfully:

```
  - Installing Config Split setup...
  - Checking for Config Split...
  - drupal/config_split already present in require-dev.
  - Lando script config-safety-check.sh already exists; skipping.
  - Lando script dev-config.sh already exists; skipping.
  - All Lando scripts have been copied successfully!
  - Added dev environment setup commands to .lando.yml post-start events
  - Successfully parsed .lando.yml file
  ```

4. Run `lando rebuild -y` and verify config split changes in the Lando config are working as expected. You should see something similar to:

```
🔧 Setting up dev environment...
⏳ Waiting for database to be ready...
✅ Database is ready
🔧 Enabling dev config split...
Configuring dev split in settings.local.php...
```

> #### 📝 Note: 
>
> If that codebase has not been updated with this latest set of config split changes, you may see error notices about the dev config split activation failing. This is expected until all necessary configs are synced.

5. Run `lando restart -y` and make sure the environment restarts without issue.