### PR TITLE
Config sync: PR/Jira report + CI safety check

### DIFF
--- a/files/scripts/config_split/config-safety-check.sh
+++ b/files/scripts/config_split/config-safety-check.sh
@@ -57,9 +57,12 @@ else
 fi
 
 # Check 4: Config sync directory is correct
+# This relies on `lando drush` and is only meaningful in a local Lando env.
+# Skip in CI (the merged config gets imported on the multidev itself).
 echo "4. Checking config sync directory setting..."
-# Check the actual Drupal config sync directory using drush
-if cd html && lando drush status --field=config-sync 2>/dev/null | grep -q "../config/sync"; then
+if [[ -n "${CI:-}" ]]; then
+    echo -e "${YELLOW}⚠ Skipping in CI (no Lando)${NC}"
+elif cd html && lando drush status --field=config-sync 2>/dev/null | grep -q "../config/sync"; then
     echo -e "${GREEN}✓ Config sync directory correctly set${NC}"
 else
     echo -e "${RED}✗ ERROR: Config sync directory not properly configured${NC}"

--- a/files/scripts/config_split/post_config_sync_comment.sh
+++ b/files/scripts/config_split/post_config_sync_comment.sh
@@ -39,8 +39,8 @@ done
 REPO="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
 
 # JSON-encode the markdown body safely.
-BODY_JSON="$(python3 -c '
-import json, os, sys
+BODY_JSON="$(REPORT_FILE="${REPORT_FILE}" python3 -c '
+import json, os
 with open(os.environ["REPORT_FILE"]) as f:
     print(json.dumps({"body": f.read()}))
 ')"

--- a/files/scripts/config_split/sync-prod-config.sh
+++ b/files/scripts/config_split/sync-prod-config.sh
@@ -113,6 +113,18 @@ echo "==> Writing sync report to ${REPORT_FILE}"
   fi
 } > "${REPORT_FILE}"
 
+echo "==> Running config safety checks on merged result"
+SAFETY_CHECK="$(dirname "$0")/config-safety-check.sh"
+if [ -x "${SAFETY_CHECK}" ]; then
+  if ! "${SAFETY_CHECK}"; then
+    echo "❌ Config safety check failed. Aborting sync before push to multidev." >&2
+    echo "_⚠️ Config safety check failed — sync aborted before multidev push._" >> "${REPORT_FILE}"
+    exit 1
+  fi
+else
+  echo "    config-safety-check.sh not found at ${SAFETY_CHECK} — skipping."
+fi
+
 echo "==> Committing merged config (if changed)"
 git add "${SYNC_DIR}"
 if git diff --cached --quiet; then

--- a/src/InstallConfigSplit.php
+++ b/src/InstallConfigSplit.php
@@ -47,6 +47,7 @@ class InstallConfigSplit {
   private $ciScripts = [
     'sync-prod-config.sh',
     'post_config_sync_comment.sh',
+    'config-safety-check.sh',
   ];
 
   public function __construct(IOInterface $io, $projectRoot) {


### PR DESCRIPTION
## Summary
- `sync-prod-config.sh` now writes a markdown report of applied/added/preserved files to `/tmp/config-sync-report.md`.
- New `post_config_sync_comment.sh` posts that report to the PR; the existing `pr-comments-to-jira` workflow mirrors it to the Jira ticket.
- `config-safety-check.sh` is now invoked from `sync-prod-config.sh` after the merge and before the multidev push. If it fails, the sync aborts and the failure is appended to the PR/Jira comment. Check #4 (lando drush) is skipped when `$CI` is set.

## Test plan
- [ ] Bump the package in a consuming Drupal project and trigger a PR.
- [ ] Confirm the PR receives a "Drupal config sync" comment listing updated/added/preserved files.
- [ ] Confirm the Jira ticket (extracted from the PR title/branch) receives the same comment via `pr-comments-to-jira.yml`.
- [ ] Verify a PR that edits a config file keeps its version (file appears under "Preserved from PR").
- [ ] Force a safety-check failure (e.g. enable a dev module in main config) and confirm the sync aborts before rsync/import.